### PR TITLE
Fix GitHub widget HTTPS URL support and missing documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,20 @@ set -g @tokyo-night-tmux_battery_low_threshold 21 # default
 Set variable value `0` to disable the widget. Remember to restart `tmux` after
 changing values.
 
+#### Web-based Git Widget
+
+This widget shows GitHub/GitLab statistics including PR counts and issues assigned to you. It requires `gh` (GitHub CLI) or `glab` (GitLab CLI) to be installed and authenticated.
+
+```bash
+set -g @tokyo-night-tmux_show_wbg 1
+```
+
+The widget works with both SSH and HTTPS git remote URLs:
+- SSH: `git@github.com:user/repo.git`
+- HTTPS: `https://github.com/user/repo.git`
+
+Set variable value `0` to disable the widget. Remember to restart `tmux` after changing values.
+
 #### Hostname Widget
 
 ```bash

--- a/src/wb-git-status.sh
+++ b/src/wb-git-status.sh
@@ -10,7 +10,7 @@ source "$CURRENT_DIR/themes.sh"
 
 cd "$1" || exit 1
 BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
-PROVIDER=$(git config remote.origin.url | awk -F '@|:' '{print $2}')
+PROVIDER=$(git config remote.origin.url | sed 's|https://||' | sed 's|git@||' | awk -F'[:/]' '{print $1}')
 
 PROVIDER_ICON=""
 


### PR DESCRIPTION
## Summary

This PR fixes two bugs in the GitHub widget that prevented it from working for many users:

1. **HTTPS URL parsing failure** - The widget only supported SSH URLs (`git@github.com:user/repo.git`) but failed silently with HTTPS URLs (`https://github.com/user/repo.git`)
2. **Undocumented required setting** - The widget required `@tokyo-night-tmux_show_wbg 1` to be set but this was nowhere in the documentation

## Changes Made

### 🔧 Fixed HTTPS URL Parsing
- Updated `src/wb-git-status.sh` to handle both SSH and HTTPS URL formats
- Changed provider detection from SSH-only regex to universal parsing
- Tested with both URL formats to ensure compatibility

### 📚 Added Missing Documentation  
- Documented the `@tokyo-night-tmux_show_wbg` setting in README
- Added examples for both SSH and HTTPS configurations
- Clarified widget requirements and setup

## Problem Details

**Before this fix:**
- Users with HTTPS git remotes saw no GitHub widget output
- Widget failed silently with no error messages  
- Setting was required but completely undocumented

**After this fix:**
- Works with both SSH and HTTPS git remote URLs
- Clear documentation explains how to enable the widget
- Users can choose their preferred git URL format

## Testing

- ✅ Verified widget works with HTTPS URLs (`https://github.com/user/repo.git`)
- ✅ Verified widget still works with SSH URLs (`git@github.com:user/repo.git`) 
- ✅ Confirmed proper GitHub API integration and PR/issue counts
- ✅ Tested documentation examples

## Impact

This fixes the GitHub widget for users who:
- Use HTTPS git remotes (very common in corporate environments)
- Follow GitHub's recommended HTTPS setup
- Have firewall restrictions that favor HTTPS over SSH

Resolves silent widget failures and improves user experience significantly.